### PR TITLE
Larger schedule embed

### DIFF
--- a/index.html
+++ b/index.html
@@ -18,6 +18,11 @@ layout: default
             </div>
             {% endif %}
         {% endfor %}
+
+        <div class="col-sm-12" style="padding-top: 12px;">
+            <iframe style="width: 100%; height:360px" src="https://docs.google.com/spreadsheets/d/1TBm2N4-du8Qb4L2JGDqDSfXNFwN5u7qSzniuqBBGBrE/pubhtml?gid=884926167&amp;single=true&amp;widget=true&amp;headers=false"></iframe>
+        </div>
+
     </div>
 </div>
 <script>
@@ -33,5 +38,3 @@ $(document).ready(function() {
     });
 });
 </script>
-
-<iframe src="https://docs.google.com/spreadsheets/d/1TBm2N4-du8Qb4L2JGDqDSfXNFwN5u7qSzniuqBBGBrE/pubhtml?gid=884926167&amp;single=true&amp;widget=true&amp;headers=false"></iframe>


### PR DESCRIPTION
The schedule was not really usable as it was pretty small. This pull request places it more neatly, although it's far from perfect (inline styling, zoom in embed too high).

---

**Before**
![screenshot from 2015-09-02 12 43 06](https://cloud.githubusercontent.com/assets/1039510/9629059/32ce16ea-5170-11e5-8776-0616d6b997fb.png)

**after**
![screenshot from 2015-09-02 12 38 03](https://cloud.githubusercontent.com/assets/1039510/9629004/dfc2399a-516f-11e5-9e56-1f6844164252.png)
